### PR TITLE
提供基础配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ Project/Templates/electron-win-x64/
 Project/Templates/electron-mac-universal.app/
 package-lock.json
 .DS_Store
+
+# 不提交pnpm的锁文件
+pnpm-lock.yaml

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# 默认 淘宝镜像
+registry=https://registry.npmmirror.com/
+
+# 设置 electron 镜像
+electron_mirror=https://mirrors.huaweicloud.com/electron/


### PR DESCRIPTION
1. 忽略提交 pnpm 包管理器的依赖锁文件。
2. 提供基础的 npm 镜像源配置。

该pr本质上是这款[未合并的pr](https://github.com/yami-pro/yami-rpg-editor/pull/4)，现在yami本体仓库不再维护了，摆烂了，故手动迁移pr到本仓库。