### PR TITLE
增加基础配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Project/Templates/electron-win-x64/
 Project/Templates/electron-mac-universal.app/
 Project/Apk/decompiled/
 package-lock.json
+pnpm-lock.yaml
 .DS_Store
 extension
 build

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# 默认 淘宝镜像
+registry=https://registry.npmmirror.com/
+
+# 设置 electron 镜像
+electron_mirror=https://mirrors.huaweicloud.com/electron/

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "yami-rpg-editor",
 	"version": "1.0.0",
 	"main": "main.js",
+	"packageManager": "pnpm@10.13.1",
 	"productName": "Yami RPG Editor",
 	"author": "Yami",
 	"description": "2D Game Editor",
@@ -35,6 +36,12 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/yami-pro/yami-rpg-editor.git"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"electron",
+			"sharp"
+		]
 	},
 	"build": {
 		"appId": "com.open.yami.rpgeditor",


### PR DESCRIPTION
1. 忽略提交 pnpm 包管理器的依赖锁文件。
2. 提供基础的 npm 镜像源配置。